### PR TITLE
`.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 max_line_length = 88
+spelling_language = en-US
 trim_trailing_whitespace = true
 
 # 2 space indentation

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 88
+trim_trailing_whitespace = true
+
+# 2 space indentation
+[{*.json,*.jsonc,*.toml,*.yml,*.yaml}]
+indent_size = 2


### PR DESCRIPTION
https://editorconfig.org/

should be compatible with `dprint` and `ruff` (default config, i.e. black style)