### PR TITLE
`numpy_typing_compat.array_api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,23 @@ to install the correct version of `numpy-typing-compat` that matches the install
 
 ## Reference
 
-The following boolean constants are available:
+<!-- TODO(jorenham): document long and ulong -->
+
+### Array API
+
+Additionally, the package provides a `numpy_typing_compat.array_api` namespace that's a re-export
+the `numpy.array_api` module on `numpy < 2.0`, or the main `numpy` module on `numpy >= 2.0`.
+Note that the `numpy.array_api` module was introduced in `numpy>=1.23`, so it is isn't available in
+`numpy-typing-compat==1.22.*`.
+
+### Version constants
+
+The following low-level boolean version constants are available:
 
 | Constant        | `True` when     |
 | --------------- | --------------- |
 | `NUMPY_GE_1_22` | `numpy >= 1.22` |
+| `NUMPY_GE_1_23` | `numpy >= 1.23` |
 | `NUMPY_GE_1_25` | `numpy >= 1.25` |
 | `NUMPY_GE_2_0`  | `numpy >= 2.0`  |
 | `NUMPY_GE_2_1`  | `numpy >= 2.1`  |
@@ -69,34 +81,3 @@ The following boolean constants are available:
 
 Each constant is typed as `Literal[True]` or `Literal[False]` depending on your NumPy version,
 allowing type checkers to perform accurate type narrowing.
-
-## Examples
-
-### `numpy.exceptions`
-
-The `numpy.exceptions` module was introduced in NumPy 1.25, and since 2.0 the exceptions
-were removed from the global `numpy` namespace. If you support both `<1.25` and `>=2.0`, you can
-conditionally import exceptions like this:
-
-```python
-from numpy_typing_compat import NUMPY_GE_1_25
-
-if NUMPY_GE_1_25:
-    from numpy.exceptions import AxisError
-else:
-    from numpy import AxisError
-```
-
-### `numpy.long`
-
-The `numpy.long` scalar type was introduced in NumPy 2.0. Before 2.0, it was named `numpy.int_`.
-
-```python
-import numpy as np
-from numpy_typing_compat import NUMPY_GE_2_0
-
-if NUMPY_GE_2_0:
-    type Long = np.long
-else:
-    type Long = np.int_
-```

--- a/build.py
+++ b/build.py
@@ -217,34 +217,6 @@ class Project:
         assert path_wheel == paths_expect.wheel, (path_wheel, paths_expect.wheel)
 
 
-PROJECTS = [
-    Project(
-        np_range=(Version(1, 22), Version(1, 25)),
-        py_range=(Version(3, 8), Version(3, 12)),
-    ),
-    Project(
-        np_range=(Version(1, 25), Version(2, 0)),
-        py_range=(Version(3, 9), Version(3, 13)),
-    ),
-    Project(
-        np_range=(Version(2, 0), Version(2, 1)),
-        py_range=(Version(3, 9), Version(3, 13)),
-    ),
-    Project(
-        np_range=(Version(2, 1), Version(2, 2)),
-        py_range=(Version(3, 10), Version(3, 14)),
-    ),
-    Project(
-        np_range=(Version(2, 2), Version(2, 3)),
-        py_range=(Version(3, 10), Version(3, 14)),
-    ),
-    Project(
-        np_range=(Version(2, 3), Version(2, 4)),
-        py_range=(Version(3, 11), Version(3, 15)),
-    ),
-]
-
-
 def _fetch_latest_release_hashes() -> DistInfo[dict[Version, tuple[int, str]]]:
     # https://peps.python.org/pep-0691/
     # https://docs.pypi.org/api/index-api/#json_1
@@ -286,6 +258,38 @@ def _fetch_latest_release_hashes() -> DistInfo[dict[Version, tuple[int, str]]]:
     return DistInfo(sdist=latest_sdists, wheel=latest_wheels)
 
 
+PROJECTS = [
+    Project(
+        np_range=(Version(1, 22), Version(1, 23)),
+        py_range=(Version(3, 8), Version(3, 11)),
+    ),
+    Project(
+        np_range=(Version(1, 23), Version(1, 25)),
+        py_range=(Version(3, 8), Version(3, 12)),
+    ),
+    Project(
+        np_range=(Version(1, 25), Version(2, 0)),
+        py_range=(Version(3, 9), Version(3, 13)),
+    ),
+    Project(
+        np_range=(Version(2, 0), Version(2, 1)),
+        py_range=(Version(3, 9), Version(3, 13)),
+    ),
+    Project(
+        np_range=(Version(2, 1), Version(2, 2)),
+        py_range=(Version(3, 10), Version(3, 14)),
+    ),
+    Project(
+        np_range=(Version(2, 2), Version(2, 3)),
+        py_range=(Version(3, 10), Version(3, 14)),
+    ),
+    Project(
+        np_range=(Version(2, 3), Version(2, 4)),
+        py_range=(Version(3, 11), Version(3, 15)),
+    ),
+]
+
+
 def main(*args: str) -> int:
     # [version]: (sha256_sdist, sha256_wheel)
     latest_hashes = _fetch_latest_release_hashes()
@@ -296,9 +300,8 @@ def main(*args: str) -> int:
         hashes = project.dist_hashes
         paths = project.dist_paths
 
-        for build_hashes, hash_, path in zip(latest_hashes, hashes, paths):
-            pypi_build, pypi_hash = build_hashes[np_version]
-
+        for build_hashes, hash_, path in zip(latest_hashes, hashes, paths, strict=True):
+            pypi_build, pypi_hash = build_hashes.get(np_version, (0, ""))
             if pypi_hash == hash_:
                 print(
                     f"no changes since {np_version}.{pypi_build} - removing {path}",

--- a/templates/__init__.py.jinja
+++ b/templates/__init__.py.jinja
@@ -1,15 +1,17 @@
 from typing import Final, Literal
 
 {% if np_start >= (2, 0) -%}
+{%- if np_start >= (1, 23) %}import numpy as array_api{% endif %}
 from numpy import long, ulong
 {%- else -%}
-from numpy import int_ as long, uint as ulong
+from numpy import array_api, int_ as long, uint as ulong
 {%- endif %}
 
 __all__ = (
     {%- for project in PROJECTS %}
     "{{ project.const_name }}",
     {%- endfor %}
+    "array_api",
     "long",
     "ulong",
 )
@@ -22,4 +24,4 @@ def __dir__() -> tuple[str, ...]:
 {% set np_other = project.np_range[0] -%}
 {% set is_ge = np_start >= np_other -%}
 {{ project.const_name }}: Final[Literal[{{ is_ge }}]] = {{ is_ge }}  # numpy >= {{ np_other }}
-{% endfor %}
+{% endfor -%}


### PR DESCRIPTION
This also splits the `1.22 : 1.25` branch into one for just `1.22 : 1.23`, and one for `1.23 : 25`. This was needed because `numpy.array_api` did not exist before `1.23`.

---

Closes #17 