### PR TITLE
Drop `numpy<2` and `python<3.10` (SPEC 0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,34 +44,15 @@ ensure that these dependency restrictions are satisfied. That way, if you upgrad
 automatically look for a version of `numpy-typing-compat` that satisfies the new `numpy`
 version, which for this example would be `numpy-typing-compat==20250818.2.3`.
 
-| numpy-typing-compat | NumPy          | Python   |
-| ------------------- | -------------- | -------- |
-| `20251206.1.22`     | `>=1.22,<1.23` | `>=3.8`  |
-| `20251206.1.23`     | `>=1.23,<1.25` | `>=3.8`  |
-| `20251206.1.25`     | `>=1.25,<2.0`  | `>=3.9`  |
-| `20251206.2.0`      | `>=2.0,<2.1`   | `>=3.9`  |
-| `20251206.2.1`      | `>=2.1,<2.2`   | `>=3.10` |
-| `20251206.2.2`      | `>=2.2,<2.3`   | `>=3.10` |
-| `20251206.2.3`      | `>=2.3,<2.4`   | `>=3.11` |
-| `20251206.2.4`      | `>=2.4,<2.5`   | `>=3.11` |
+| numpy-typing-compat | NumPy        | Python   |
+| ------------------- | ------------ | -------- |
+| `20251206.2.0`      | `>=2.0,<2.1` | `>=3.10` |
+| `20251206.2.1`      | `>=2.1,<2.2` | `>=3.10` |
+| `20251206.2.2`      | `>=2.2,<2.3` | `>=3.10` |
+| `20251206.2.3`      | `>=2.3,<2.4` | `>=3.11` |
+| `20251206.2.4`      | `>=2.4,<2.5` | `>=3.11` |
 
 ## Reference
-
-### `array_api`
-
-Additionally, the package provides a `numpy_typing_compat.array_api` namespace that's a
-re-export of the `numpy.array_api` module on `numpy < 2.0`, or the main `numpy` module
-on `numpy >= 2.0`. Note that the `numpy.array_api` module was introduced in
-`numpy >= 1.23`, so it isn't available in e.g. `numpy-typing-compat==20250818.1.22`.
-
-### `long` and `ulong`
-
-NumPy 2.0 introduced the new `long` and `ulong` scalar types, which are not available in
-`numpy < 2.0`, and instead went by the names `int_` and `uint` (which in `numpy >= 2.0`
-are aliases for `intp` and `uintp`).
-If you need to support both NumPy versions, you can use the `long` and `ulong` types
-from `numpy_typing_compat`, which on `numpy < 2.0` are aliases for `np.int_` and
-`np.uint`, and on `numpy >= 2.0` are re-exports of `np.long` and `np.ulong`.
 
 ### `StringDType`
 
@@ -106,16 +87,13 @@ provided. These are type aliases for `Literal[True]` and `Literal[False]` on
 
 The following low-level boolean version constants are available:
 
-| Constant        | `True` when     |
-| --------------- | --------------- |
-| `NUMPY_GE_1_22` | `numpy >= 1.22` |
-| `NUMPY_GE_1_23` | `numpy >= 1.23` |
-| `NUMPY_GE_1_25` | `numpy >= 1.25` |
-| `NUMPY_GE_2_0`  | `numpy >= 2.0`  |
-| `NUMPY_GE_2_1`  | `numpy >= 2.1`  |
-| `NUMPY_GE_2_2`  | `numpy >= 2.2`  |
-| `NUMPY_GE_2_3`  | `numpy >= 2.3`  |
-| `NUMPY_GE_2_4`  | `numpy >= 2.4`  |
+| Constant       | `True` when    |
+| -------------- | -------------- |
+| `NUMPY_GE_2_0` | `numpy >= 2.0` |
+| `NUMPY_GE_2_1` | `numpy >= 2.1` |
+| `NUMPY_GE_2_2` | `numpy >= 2.2` |
+| `NUMPY_GE_2_3` | `numpy >= 2.3` |
+| `NUMPY_GE_2_4` | `numpy >= 2.4` |
 
 Each constant is typed as `Literal[True]` or `Literal[False]` depending on your NumPy
 version, so that static type-checkers are able to understand the NumPy version being

--- a/build.py
+++ b/build.py
@@ -302,20 +302,8 @@ class Project:
 
 PROJECTS = [
     Project(
-        np_range=(Version(1, 22), Version(1, 23)),
-        py_range=(Version(3, 8), Version(3, 11)),
-    ),
-    Project(
-        np_range=(Version(1, 23), Version(1, 25)),
-        py_range=(Version(3, 8), Version(3, 12)),
-    ),
-    Project(
-        np_range=(Version(1, 25), Version(2, 0)),
-        py_range=(Version(3, 9), Version(3, 13)),
-    ),
-    Project(
         np_range=(Version(2, 0), Version(2, 1)),
-        py_range=(Version(3, 9), Version(3, 13)),
+        py_range=(Version(3, 10), Version(3, 13)),
     ),
     Project(
         np_range=(Version(2, 1), Version(2, 2)),

--- a/templates/__init__.py.jinja
+++ b/templates/__init__.py.jinja
@@ -1,5 +1,3 @@
-# ruff: noqa: I001
-{% if py_start >= (3, 10) -%}
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -13,34 +11,11 @@ from typing import (
 {%- endif %}
     TypeVar,
 )
-{%- else -%}
-import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Final,
-    Literal,
-{%- if np_start >= (2, 1) %}
-    Protocol,
-{%- endif %}
-{%- if py_start < (3, 9) %}
-    Tuple,
-{%- endif  %}
-    TypeVar,
-)
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
-{%- endif %}{# py_start >= (3, 10) #}
 
 if TYPE_CHECKING:
     import numpy as np
 
 {%- if np_start >= (2, 1) %}{# >=2.1 #}
-    import numpy as array_api
-    from numpy import long, ulong
     from numpy.dtypes import StringDType
 {%- if np_start >= (2, 2) %}{# >=2.2 #}
     from numpy.polynomial._polybase import ABCPolyBase
@@ -50,27 +25,13 @@ if TYPE_CHECKING:
 
     ABCPolyBase: TypeAlias = _ABCPolyBase[LiteralString | None]
 {%- endif %}{# >=2.1 #}
-{%- elif np_start >= (2, 0) -%}{# >=2.0, <2.1 #}
-    import numpy as array_api
-    from numpy import dtype, long, ulong
+{%- else -%}{# >=2.0, <2.1 #}
+    from numpy import dtype
     from numpy.polynomial._polybase import ABCPolyBase
     from typing_extensions import Never
 
     StringDType: TypeAlias = dtype[Never]
-{%- else -%}{# <2.0 #}
-    from typing_extensions import Never
-
-    from numpy.polynomial._polybase import ABCPolyBase
-    from numpy import int_ as long
-    from numpy import uint as ulong
-{%- if np_start >= (1, 23) %}{# >=1.23, <2.0 #}
-    from numpy import array_api
-
-{% else -%}{# <1.23 #}
-    array_api: TypeAlias = Never  # noqa: PYI042
-{%- endif %}{# >=1.23, <2.0 #}
-    StringDType: TypeAlias = Never
-{%- endif %}{# >=2.1 #}
+{%- endif %}
 
 
 __version__: Final = "{{ project.version }}"
@@ -86,12 +47,9 @@ __all__ = (
     "StringDType",
     "__version__",
     "_check_version",
-    "array_api",
-    "long",
-    "ulong",
 )
 
-def __dir__() -> {% if py_start >= (3, 9) %}tuple[str, ...]:{% else %}Tuple[str, ...]:  # noqa: FA100{% endif %}
+def __dir__() -> tuple[str, ...]:
     return __all__
 
 
@@ -104,24 +62,9 @@ def __getattr__(name: str, /) -> object:
         from numpy import ndarray
         return ndarray
 {%- endif %}
-{% if np_start >= (2, 0) %}
     if name == "StringDType":
         from numpy.dtypes import StringDType
         return StringDType
-{%- endif %}
-{% if np_start >= (1, 23) %}
-    if name == "array_api":
-        import numpy{% if np_start < (2, 0) %}.array_api{% endif %} as array_api{% if np_start < (2, 0) %}  # noqa: PLR0402{% endif %}
-        return array_api
-{%- endif %}
-
-    if name == "long":
-        from numpy import {% if np_start < (2, 0) %}int_ as {% endif %}long
-        return long
-
-    if name == "ulong":
-        from numpy import {% if np_start < (2, 0) %}uint as {% endif %}ulong
-        return ulong
 
     if name == "ABCPolyBase":
         from numpy.polynomial._polybase import ABCPolyBase

--- a/templates/pyproject.toml.jinja
+++ b/templates/pyproject.toml.jinja
@@ -25,9 +25,6 @@ classifiers = [
 requires-python = ">={{ py_start }}"
 dependencies = [
   "numpy >={{ np_start }}, <{{ np_stop }}",
-{%- if py_start < (3, 10) %}
-  "typing_extensions >=4; python_version < '3.10'",
-{%- endif %}
 ]
 
 [project.urls]


### PR DESCRIPTION
https://scientific-python.org/specs/spec-0000/

This also means that the `array_api`, `long`, and `ulong` reexports are no longer needed, and are, therefore, removed.