### PR TITLE
increase python upper bound for numpy 2.5

### DIFF
--- a/build.py
+++ b/build.py
@@ -323,7 +323,7 @@ PROJECTS = [
     ),
     Project(
         np_range=(Version(2, 5, "rc1"), Version(2, 6)),
-        py_range=(Version(3, 12), Version(3, 15)),
+        py_range=(Version(3, 12), Version(3, 16)),
     ),
 ]
 


### PR DESCRIPTION
`numpy==2.5.0rc1` doesn't support Python 3.15 yet, but the final `numpy==2.5.0` release will.